### PR TITLE
Trad set time/alarm bug fix

### DIFF
--- a/firmware/inc/display.h
+++ b/firmware/inc/display.h
@@ -115,7 +115,7 @@
 
 typedef enum brightness_levels_t
 {
-    LOW_BRIGHTNESS = 0,
+    LOW_BRIGHTNESS = 7,
     MED_BRIGHTNESS = 30,
     HIGH_BRIGHTNESS = 150,
 } BrightnessLevels;

--- a/firmware/src/display.c
+++ b/firmware/src/display.c
@@ -296,7 +296,7 @@ ClockStatus Display_Init(Display *self, ExternVars *vars)
 
     g_fsm.ctx->setColour(row1_bitmap.num, RED);    // Row1 Red
     g_fsm.ctx->setColour(row2_bitmap.num, CYAN);    // Row2 Cyan
-    g_fsm.ctx->setColour(row3_bitmap.num, BLUE);    // Row3 Blue
+    g_fsm.ctx->setColour(row3_bitmap.num, MAGENTA);    // Row3 Blue
 
     g_fsm.ctx->setBitmap(row1_bitmap.num, row1_bitmap.p_bitmap);
     g_fsm.ctx->setBitmap(row2_bitmap.num, row2_bitmap.p_bitmap);
@@ -489,7 +489,7 @@ static void ShowTime_Update(Display *ctx)
     memset(row3_bitmap.p_bitmap, 0, row3_bitmap.bitmap_size);
     if (*ctx->clock_vars->timer_set && *ctx->clock_vars->alarm_set) {
         if (*ctx->clock_vars->timer_alarm_displayed == DISPLAY_ALARM) {
-            row3_colour = BLUE;
+            row3_colour = MAGENTA;
             displayTime(&row3_bitmap, *ctx->clock_vars->user_alarm_ms);
         } else if (*ctx->clock_vars->timer_alarm_displayed == DISPLAY_TIMER) {
             row3_colour = GREEN;
@@ -499,7 +499,7 @@ static void ShowTime_Update(Display *ctx)
         row3_colour = GREEN;
         displayTime(&row3_bitmap, *ctx->clock_vars->user_timer_ms);
     } else if (*ctx->clock_vars->alarm_set) {
-        row3_colour = BLUE;
+        row3_colour = MAGENTA;
         displayTime(&row3_bitmap, *ctx->clock_vars->user_alarm_ms);
     }
 
@@ -538,7 +538,7 @@ static void SetTime_Update(Display *ctx)
     memset(row3_bitmap.p_bitmap, 0, row3_bitmap.bitmap_size);
     if (*ctx->clock_vars->timer_set && *ctx->clock_vars->alarm_set) {
         if (*ctx->clock_vars->timer_alarm_displayed == DISPLAY_ALARM) {
-            row3_colour = BLUE;
+            row3_colour = MAGENTA;
             displayTime(&row3_bitmap, *ctx->clock_vars->user_alarm_ms);
         } else if (*ctx->clock_vars->timer_alarm_displayed == DISPLAY_TIMER) {
             row3_colour = GREEN;
@@ -548,7 +548,7 @@ static void SetTime_Update(Display *ctx)
         row3_colour = GREEN;
         displayTime(&row3_bitmap, *ctx->clock_vars->user_timer_ms);
     } else if (*ctx->clock_vars->alarm_set) {
-        row3_colour = BLUE;
+        row3_colour = MAGENTA;
         displayTime(&row3_bitmap, *ctx->clock_vars->user_alarm_ms);
     }
 
@@ -640,7 +640,7 @@ static void SetAlarm_Entry(Display *ctx)
     ctx->show(ROW_2);
     ctx->show(ROW_3);
     
-    row3_colour = BLUE;
+    row3_colour = MAGENTA;
     row3_colour_old = row3_colour;
     ctx->setColour(row3_bitmap.num, row3_colour);
 }

--- a/firmware/src/doz_clock.c
+++ b/firmware/src/doz_clock.c
@@ -352,6 +352,8 @@ void SetAlarm_Update(DozClock *ctx)
             } else { // TRAD_12H
                 if (ctx->digit_vals[6] == 1 && (10*ctx->digit_vals[0] + ctx->digit_vals[1]) != 12) // PM && hour != 12
                     ctx->user_alarm_ms += (uint32_t) (10*ctx->digit_vals[0] + ctx->digit_vals[1] + 12) * 3600000;
+                else if (ctx->digit_vals[6] == 0 && (10*ctx->digit_vals[0] + ctx->digit_vals[1]) == 12) // AM && hour == 12
+                    ctx->user_alarm_ms += 0;
                 else
                     ctx->user_alarm_ms += (uint32_t) (10*ctx->digit_vals[0] + ctx->digit_vals[1]) * 3600000;
             }
@@ -530,6 +532,8 @@ void SetTime_Update(DozClock *ctx)
             } else { // TRAD_12H
                 if (ctx->digit_vals[6] == 1 && (10*ctx->digit_vals[0] + ctx->digit_vals[1]) != 12) // PM && hour != 12
                     ctx->user_time_ms += (uint32_t) (10*ctx->digit_vals[0] + ctx->digit_vals[1] + 12) * 3600000;
+                else if (ctx->digit_vals[6] == 0 && (10*ctx->digit_vals[0] + ctx->digit_vals[1]) == 12) // AM && hour == 12
+                    ctx->user_alarm_ms += 0;
                 else
                     ctx->user_time_ms += (uint32_t) (10*ctx->digit_vals[0] + ctx->digit_vals[1]) * 3600000;
             }


### PR DESCRIPTION
- Set alarm display colour to magenta
- In set alarm or set time modes the time can now be set to 12Am with out it automatically reverting to 12PM
- Increased low brightness setting from 0 to 7